### PR TITLE
feat: support JSON extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ const cacheFreeRequire = makeRequire(__dirname);
 cacheFreeRequire('./path/to/module');
 cacheFreeRequire('some-module');
 ```
+
+## notice
+
+Only support `.js` and `.json`, other file will be treated as `.js`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Require modules with no caching in Node.js.
 
 ## why
 
-In developing Node.js apps, we need to restart nodeserver every time code changed. Using nodemon maybe a way to solve this. But when the nodeserver is too complicated, it's time consuming to restart.
+In developing Node.js apps, we need to restart Node.js server every time code changed. Using nodemon maybe a way to solve this. But when the Node.js server is too complicated, it's time consuming to restart.
 
 `cache-free-require` is suitable when we frequently change a little parts of code.
 
@@ -30,4 +30,5 @@ cacheFreeRequire('some-module');
 
 ## notice
 
-Only support `.js` and `.json`, other file will be treated as `.js`.
+- Only support `.js` and `.json`, other file will be treated as `.js`.
+- Only can be used on files with no state, otherwise the state will not be persisted.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-free-require",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Require modules with no caching in Node.js.",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,11 @@ exports.cacheFreeRequire = function(moduleName, dirname, filename = 'temp-file.j
     const path = require.resolve(moduleName, {paths: [loaderContext.context, ...module.paths]});
     const content = fs.readFileSync(path, 'utf-8');
     module.filename = filename;
-    module._compile(content, filename);
+
+    // json file is parsed and is assigned to the module exports property
+    if (filename.endsWith('.js')) {
+        module._compile(content, filename);
+    }
   
     return module.exports;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -10,15 +10,19 @@ exports.makeRequire = function(dirname) {
 
 exports.cacheFreeRequire = function(moduleName, dirname) {
     const loaderContext = {context: dirname};
-    const module = new NativeModule(filename, loaderContext);
-  
-    module.paths = NativeModule._nodeModulePaths(loaderContext.context);
-    const path = require.resolve(moduleName, {paths: [loaderContext.context, ...module.paths]});
-    const content = fs.readFileSync(path, 'utf-8');
+    const module = new Module('fake cache free module', loaderContext);
+
+    module.paths = Module._nodeModulePaths(loaderContext.context);
+    const filePath = require.resolve(moduleName, {paths: [loaderContext.context, ...module.paths]});
+    const content = fs.readFileSync(filePath, 'utf-8');
+
+    const filename = filePath;
     module.filename = filename;
 
-    // json file is parsed and is assigned to the module exports property
-    if (filename.endsWith('.js')) {
+    if (module.filename.endsWith('.json')) {
+        module.exports = JSON.parse(content);
+    }
+    else {
         module._compile(content, filename);
     }
   

--- a/src/index.js
+++ b/src/index.js
@@ -1,24 +1,28 @@
 const fs = require('fs');
 const Module = require('module');
+const path = require('path');
 
 exports.makeRequire = function(dirname) {
-    return function(moduleName, filename) {
-        return exports.require(moduleName, dirname, filename);
+    return function(moduleName) {
+        return exports.require(moduleName, dirname);
     }
 }
 
-exports.cacheFreeRequire = function(moduleName, dirname, filename = 'temp-file.js') {
+exports.cacheFreeRequire = function(moduleName, dirname) {
     const loaderContext = {context: dirname};
-    const module = new Module(filename, loaderContext);
+    const module = new Module('fake cache free module', loaderContext);
   
     module.paths = Module._nodeModulePaths(loaderContext.context);
-    const path = require.resolve(moduleName, {paths: [loaderContext.context, ...module.paths]});
-    console.log(path);
-    const content = fs.readFileSync(path, 'utf-8');
-    module.filename = filename;
+    const filePath = require.resolve(moduleName, {paths: [loaderContext.context, ...module.paths]});
+    console.log(filePath);
+    const content = fs.readFileSync(filePath, 'utf-8');
+    module.filename = path.basename(filePath);
+    console.log(module.filename);
 
-    // json file is parsed and is assigned to the module exports property
-    if (filename.endsWith('.js')) {
+    if (module.filename.endsWith('.json')) {
+        module.exports = JSON.parse(content);
+    }
+    else {
         module._compile(content, filename);
     }
   

--- a/src/index.js
+++ b/src/index.js
@@ -11,13 +11,11 @@ exports.makeRequire = function(dirname) {
 exports.cacheFreeRequire = function(moduleName, dirname) {
     const loaderContext = {context: dirname};
     const module = new Module('fake cache free module', loaderContext);
-  
+
     module.paths = Module._nodeModulePaths(loaderContext.context);
     const filePath = require.resolve(moduleName, {paths: [loaderContext.context, ...module.paths]});
-    console.log(filePath);
     const content = fs.readFileSync(filePath, 'utf-8');
     module.filename = path.basename(filePath);
-    console.log(module.filename);
 
     if (module.filename.endsWith('.json')) {
         module.exports = JSON.parse(content);

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const NativeModule = require('module');
+const Module = require('module');
 
 exports.makeRequire = function(dirname) {
     return function(moduleName, filename) {
@@ -9,13 +9,18 @@ exports.makeRequire = function(dirname) {
 
 exports.cacheFreeRequire = function(moduleName, dirname, filename = 'temp-file.js') {
     const loaderContext = {context: dirname};
-    const module = new NativeModule(filename, loaderContext);
+    const module = new Module(filename, loaderContext);
   
-    module.paths = NativeModule._nodeModulePaths(loaderContext.context);
+    module.paths = Module._nodeModulePaths(loaderContext.context);
     const path = require.resolve(moduleName, {paths: [loaderContext.context, ...module.paths]});
+    console.log(path);
     const content = fs.readFileSync(path, 'utf-8');
     module.filename = filename;
-    module._compile(content, filename);
+
+    // json file is parsed and is assigned to the module exports property
+    if (filename.endsWith('.js')) {
+        module._compile(content, filename);
+    }
   
     return module.exports;
 }


### PR DESCRIPTION
For JSON extensions, the content of the file is parsed and is assigned to the module exports property.
For Javascript, files need module._compile().